### PR TITLE
docs: This patch updates syntax for yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To run this site you need:
 To install the yarn requirements;
 
 ```sh
-yarn install
+yarn
 ```
 
 ### Development


### PR DESCRIPTION
It's a very tiny change, but the syntax of yarn has shifted to
no longer require to use of "install", it's inferred now.